### PR TITLE
WIP: implementation of malloc hooks using LD_PRELOAD

### DIFF
--- a/ld_preload/Makefile
+++ b/ld_preload/Makefile
@@ -1,0 +1,17 @@
+##
+## Makefile for mallhook
+## mallhook is a library that wraps all malloc family functions
+##
+
+NAME = mallhook.so
+SRC = mallhook.c
+
+all: $(NAME)
+
+$(NAME):
+	gcc $(SRC) -shared -fPIC -o $(NAME) -W -Wall -Wextra -ansi -O3 -pipe -ldl
+
+clean:
+	rm -f $(NAME)
+
+re:	clean all

--- a/ld_preload/mallhook.c
+++ b/ld_preload/mallhook.c
@@ -87,7 +87,7 @@ void *malloc(size_t size) {
     snprintf(buf + n, 256 - n, "%p\n", p);
   else
     snprintf(buf + n, 256 - n, "0\n");
-  write(outfile, buf, strlen(buf));
+  (void) write(outfile, buf, strlen(buf));
   return p;
 }
 
@@ -107,7 +107,7 @@ void *calloc(size_t nmemb, size_t size) {
     snprintf(buf + n, 256 - n, "%p\n", p);
   else
     snprintf(buf + n, 256 - n, "0\n");
-  write(outfile, buf, strlen(buf));
+  (void) write(outfile, buf, strlen(buf));
   return p;
 }
 
@@ -130,7 +130,7 @@ void *realloc(void *ptr, size_t size) {
     snprintf(buf + n, 256 - n, "%p\n", p);
   else
     snprintf(buf + n, 256 - n, "0\n");
-  write(outfile, buf, strlen(buf));
+  (void) write(outfile, buf, strlen(buf));
   return p;
 }
 
@@ -146,7 +146,7 @@ void free(void *ptr) {
     snprintf(buf, 256, "free(0) = <void>\n");
 
   r_free(ptr);
-  write(outfile, buf, strlen(buf));
+  (void) write(outfile, buf, strlen(buf));
 }
 
 /*

--- a/ld_preload/mallhook.c
+++ b/ld_preload/mallhook.c
@@ -1,0 +1,169 @@
+#define _GNU_SOURCE
+
+#include <string.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <dlfcn.h>
+
+#define STR_NX(A) #A
+#define STR(A) STR_NX(A)
+
+typedef enum {
+  MALLOC,
+  CALLOC,
+  REALLOC,
+  FREE
+} func;
+
+static int outfile = -1;
+
+static void *(*r_malloc)(size_t) = NULL;
+static void *(*r_calloc)(size_t, size_t) = NULL;
+static void *(*r_realloc)(void *, size_t) = NULL;
+static void (*r_free)(void *) = NULL;
+
+static void mtrace_init(func name) {
+
+  switch (name) {
+  case MALLOC:
+    r_malloc = dlsym(RTLD_NEXT, "malloc");
+    if (r_malloc == NULL)
+      goto dl_error;
+    break;
+
+  case CALLOC:
+    r_calloc = dlsym(RTLD_NEXT, "calloc");
+    if (r_calloc == NULL)
+      goto dl_error;
+    break;
+
+  case REALLOC:
+    r_realloc = dlsym(RTLD_NEXT, "realloc");
+    if (r_realloc == NULL)
+      goto dl_error;
+    break;
+
+  case FREE:
+    r_free = dlsym(RTLD_NEXT, "free");
+    if (r_free == NULL) 
+      goto dl_error;
+    break;
+  }
+
+  if (outfile == -1) {
+    char *outname = NULL;
+
+    if ((outname = getenv("MALLHOOK_OUT")) == NULL)
+      outname = "output";
+    outfile = open(outname, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+    
+    if (outfile == -1) {
+      fprintf(stderr, "[Mallhook] failed to open output file\n");
+    }
+  }
+  return;
+
+ dl_error:
+  fprintf(stderr, "[Mallhook] dlsym error: %s\n", dlerror());
+  exit(EXIT_FAILURE);
+}
+
+void *malloc(size_t size) {
+  int n = 0;
+  char buf[256] = {};
+  void *p = NULL;
+
+  if (r_malloc == NULL) {
+    mtrace_init(MALLOC);
+  }
+  n = snprintf(buf, 256, "malloc(%lu) = ", size);
+
+  p = r_malloc(size);
+
+  if (p != NULL)
+    snprintf(buf + n, 256 - n, "%p\n", p);
+  else
+    snprintf(buf + n, 256 - n, "0\n");
+  write(outfile, buf, strlen(buf));
+  return p;
+}
+
+void *calloc(size_t nmemb, size_t size) {
+  int n = 0;
+  char buf[256] = {};
+  void *p = NULL;
+
+  if (r_calloc == NULL) {
+    mtrace_init(CALLOC);
+  }
+  n = snprintf(buf, 256, "calloc(%lu, %lu) = ", nmemb, size);
+
+  p = r_calloc(nmemb, size);
+
+  if (p != NULL)
+    snprintf(buf + n, 256 - n, "%p\n", p);
+  else
+    snprintf(buf + n, 256 - n, "0\n");
+  write(outfile, buf, strlen(buf));
+  return p;
+}
+
+void *realloc(void *ptr, size_t size) {
+  int n = 0;
+  char buf[256] = {};
+  void *p = NULL;
+
+  if (r_realloc == NULL) {
+    mtrace_init(REALLOC);
+  }
+  if (ptr != NULL) /* just to display ltrace's style */
+    n = snprintf(buf, 256,  "realloc(%p, %lu) = ", ptr, size);
+  else
+    n = snprintf(buf, 256,  "realloc(0, %lu) = ", size);
+
+  p = r_realloc(ptr, size);
+
+  if (p != NULL)
+    snprintf(buf + n, 256 - n, "%p\n", p);
+  else
+    snprintf(buf + n, 256 - n, "0\n");
+  write(outfile, buf, strlen(buf));
+  return p;
+}
+
+void free(void *ptr) {
+  char buf[256] = {};
+
+  if (r_free == NULL) {
+    mtrace_init(FREE);
+  }
+  if (ptr != NULL)
+    snprintf(buf, 256, "free(%p) = <void>\n", ptr);
+  else
+    snprintf(buf, 256, "free(0) = <void>\n");
+
+  r_free(ptr);
+  write(outfile, buf, strlen(buf));
+}
+
+/*
+  this is necessary to properly close the file
+*/
+void __attribute__((noreturn)) exit(int status) {
+  close(outfile);
+#ifdef __i386__
+  __asm__("movl $1, %%eax\n\t"
+      "movl %0, %%ebx\n\t"
+      "int 0x80"
+      ::"r"(status));
+#elif defined __x86_64__
+  __asm__("movq $60, %%rax\n\t"
+      "movl %0, %%ebx\n\t"
+      "syscall"
+      ::"r"(status));
+#endif
+  while (1);
+}


### PR DESCRIPTION
This is an implementation of library hooking malloc, realloc, calloc and free using LD_PRELOAD. It is still a work in progress because the given results are, in some cases, different from those given by ltrace.
For example using the following test code:

``` C
#include <stdlib.h>

int    main(int argc, char **argv)
{
  (void) argc, (void) argv;

  void *a;
  int i;

  for (i = 0; i < 10; ++i)
    {
      a = malloc(i * 1000);
      if (i % 2)
    free(a);
    }

  return 0;
}
```

will produce the same output as ltrace.
However, when I tried to run it with the ls command, the result were a bit different.

 For testing purpose, you can use the Makefile:

```
make
```

and launching a program is done by doing:

```
LD_PRELOAD=/path/to/mallhook.so command
```
