### PR TITLE
DTrace support for OS X

### DIFF
--- a/dtracetool/README.md
+++ b/dtracetool/README.md
@@ -1,0 +1,6 @@
+Villoc DTrace Tool
+==================
+
+This is a DTrace tool which aims to create an ltrace compatible output for 
+heap management functions which can be visualised by villoc.
+

--- a/dtracetool/README.md
+++ b/dtracetool/README.md
@@ -4,3 +4,10 @@ Villoc DTrace Tool
 This is a DTrace tool which aims to create an ltrace compatible output for 
 heap management functions which can be visualised by villoc.
 
+Usage
+-----
+
+```shell
+$ sudo ./memtrace.d -c <app> | ./villoc.py - out.html
+```
+

--- a/dtracetool/README.md
+++ b/dtracetool/README.md
@@ -1,8 +1,10 @@
-Villoc DTrace Tool
-==================
+DTrace Memory Tracer
+====================
 
 This is a DTrace tool which aims to create an ltrace compatible output for 
 heap management functions which can be visualised by villoc.
+
+Tested only on OS X. Other supported platforms may require modificatons.
 
 Usage
 -----

--- a/dtracetool/memtrace.d
+++ b/dtracetool/memtrace.d
@@ -23,12 +23,6 @@ to a certain degree via DTrace tuning [2] [3].
 #pragma D option destructive
 #pragma D option bufsize=256m
 
-/*
-TODO:
-    o More testing (custom test for each function)
-    o Customize villoc.py for reallocf() and valloc()
-    o Do we need all these predicates?
-*/
 
 pid$target::malloc:entry
 {
@@ -37,7 +31,7 @@ pid$target::malloc:entry
 
 pid$target::malloc:return
 {
-    printf("malloc(%#d) = %#p\n", self->msize, arg1);
+    printf("malloc(%d) = %#p\n", self->msize, arg1);
     self->msize = 0;
 }
 

--- a/dtracetool/memtrace.d
+++ b/dtracetool/memtrace.d
@@ -30,6 +30,7 @@ pid$target::malloc:entry
 }
 
 pid$target::malloc:return
+/self->msize/
 {
     printf("malloc(%d) = %#p\n", self->msize, arg1);
     self->msize = 0;

--- a/dtracetool/memtrace.d
+++ b/dtracetool/memtrace.d
@@ -1,0 +1,102 @@
+#!/usr/sbin/dtrace -s
+
+/*
+memtrace.d - DTrace-based memory allocation tracer
+Andrzej Dyjak <dyjakan@sigsegv.pl>
+
+Based on ltrace output style. Compatible with villoc [1].
+
+$ sudo dtrace ./memtrace.d -p <pid>
+$ sudo dtrace ./memtrace.d -c <application>
+
+NOTE: For bigger programs you may stumble upon data drops. This can be mitigated
+to a certain degree via DTrace tuning [2] [3].
+
+[1] https://github.com/wapiflapi/villoc
+[2] https://wikis.oracle.com/display/DTrace/Buffers+and+Buffering
+[3] https://wikis.oracle.com/display/DTrace/Options+and+Tunables
+*/
+
+/* Re-enable to see potential data drops */
+#pragma D option quiet
+
+#pragma D option destructive
+#pragma D option bufsize=256m
+
+/*
+TODO:
+    o More testing (custom test for each function)
+    o Customize villoc.py for reallocf() and valloc()
+    o Do we need all these predicates?
+*/
+
+pid$target::malloc:entry
+{
+    self->msize = arg0;
+}
+
+pid$target::malloc:return
+{
+    printf("malloc(%#d) = %#p\n", self->msize, arg1);
+    self->msize = 0;
+}
+
+pid$target::valloc:entry
+{
+    self->vsize = arg0;
+}
+
+pid$target::valloc:return
+/self->vsize/
+{
+    printf("valloc(%d) = %#p\n", self->vsize, arg1);
+    self->vsize = 0;
+}
+
+pid$target::calloc:entry
+{
+    self->ccount = arg0;
+    self->csize = arg1;
+}
+
+pid$target::calloc:return
+/self->csize/
+{
+    printf("calloc(%d, %d) = %#p\n", self->ccount, self->csize, arg1);
+    self->ccount = 0;
+    self->csize = 0;
+}
+
+pid$target::realloc:entry
+{
+    self->raddr = arg0;
+    self->rsize = arg1;
+}
+
+pid$target::realloc:return
+/self->rsize/
+{
+    printf("realloc(%#p, %d) = %#p\n", self->raddr, self->rsize, arg1);
+    self->rsize = 0;
+    self->raddr = 0;
+}
+
+pid$target::reallocf:entry
+{
+    self->rfaddr = arg0;
+    self->rfsize = arg1;
+}
+
+pid$target::reallocf:return
+/self->rfsize/
+{
+    printf("reallocf(%#p, %d) = %#p\n", self->rfaddr, self->rfsize, arg1);
+    self->rfaddr = 0;
+    self->rfsize = 0;
+}
+
+pid$target::free:entry
+{
+    printf("free(%#p) = 0\n", arg0);
+}
+

--- a/dtracetool/memtrace.d
+++ b/dtracetool/memtrace.d
@@ -23,112 +23,72 @@ to a certain degree via DTrace tuning [2] [3].
 
 pid$target::malloc:entry
 {
-    msize = arg0;
-    malloc_fail = 1
+    self->msize = arg0;
 }
 
 pid$target::malloc:return
-/msize/
+/self->msize/
 {
-    printf("malloc(%d) = %#p\n", msize, arg1);
-    msize = 0;
-    malloc_fail = 0;
+    printf("malloc(%d) = %#p\n", self->msize, arg1);
+    self->msize = 0;
 }
 
 pid$target::valloc:entry
 {
-    vsize = arg0;
-    valloc_fail = 1;
+    self->vsize = arg0;
 }
 
 pid$target::valloc:return
-/vsize/
+/self->vsize/
 {
-    printf("valloc(%d) = %#p\n", vsize, arg1);
-    vsize = 0;
-    valloc_fail = 0;
+    printf("valloc(%d) = %#p\n", self->vsize, arg1);
+    self->vsize = 0;
 }
 
 pid$target::calloc:entry
 {
-    ccount = arg0;
-    csize = arg1;
-    calloc_fail = 1;
+    self->ccount = arg0;
+    self->csize = arg1;
 }
 
 pid$target::calloc:return
-/csize/
+/self->csize/
 {
-    printf("calloc(%d, %d) = %#p\n", ccount, csize, arg1);
-    ccount = 0;
-    csize = 0;
-    calloc_fail = 0;
+    printf("calloc(%d, %d) = %#p\n", self->ccount, self->csize, arg1);
+    self->ccount = 0;
+    self->csize = 0;
 }
 
 pid$target::realloc:entry
 {
-    raddr = arg0;
-    rsize = arg1;
-    realloc_fail = 1;
+    self->raddr = arg0;
+    self->rsize = arg1;
 }
 
 pid$target::realloc:return
-/rsize/
+/self->rsize/
 {
-    printf("realloc(%#p, %d) = %#p\n", raddr, rsize, arg1);
-    rsize = 0;
-    raddr = 0;
-    realloc_fail = 0;
+    printf("realloc(%#p, %d) = %#p\n", self->raddr, self->rsize, arg1);
+    self->rsize = 0;
+    self->raddr = 0;
 }
 
 pid$target::reallocf:entry
 {
-    rfaddr = arg0;
-    rfsize = arg1;
-    reallocf_fail = 1;
+    self->rfaddr = arg0;
+    self->rfsize = arg1;
 }
 
 pid$target::reallocf:return
-/rfsize/
+/self->rfsize/
 {
-    printf("reallocf(%#p, %d) = %#p\n", rfaddr, rfsize, arg1);
-    rfaddr = 0;
-    rfsize = 0;
-    reallocf_fail = 0;
+    printf("reallocf(%#p, %d) = %#p\n", self->rfaddr, self->rfsize, arg1);
+    self->rfaddr = 0;
+    self->rfsize = 0;
 }
 
 pid$target::free:entry
 {
     printf("free(%#p) = <void>\n", arg0);
-}
-
-dtrace:::END
-/malloc_fail == 1/
-{
-    printf("malloc(%d) = <error>\n", msize);
-}
-
-dtrace:::END
-/valloc_fail == 1/
-{
-    printf("valloc(%d) = <error>\n", vsize);
-}
-
-dtrace:::END
-/calloc_fail == 1/
-{
-    printf("calloc(%d, %d) = <error>\n", ccount, csize);
-}
-
-dtrace:::END
-/realloc_fail == 1/
-{
-    printf("realloc(%#p, %d) = <error>\n", raddr, rsize);
-}
-
-dtrace:::END
-/reallocf_fail == 1/
-{
-    printf("reallocf(%#p, %d) = <error>\n", rfaddr, rfsize);
 }
 

--- a/dtracetool/memtrace.d
+++ b/dtracetool/memtrace.d
@@ -20,75 +20,130 @@ to a certain degree via DTrace tuning [2] [3].
 /* Re-enable to see potential data drops */
 #pragma D option quiet
 
+/* Globals for alloc functions args. Explicitly typed to avoid errors. */
+size_t malloc_size;
+size_t valloc_size;
+size_t calloc_count;
+size_t calloc_size;
+int64_t realloc_addr;
+size_t realloc_size;
+int64_t reallocf_addr;
+size_t reallocf_size;
+int64_t free_addr;
+
+BEGIN
+{
+    /* Flags for failure inside of the functions */
+    /* However, we're using them also for predicates. This is a hack. */
+    malloc_fail = 0;
+    valloc_fail = 0;
+    calloc_fail = 0;
+    realloc_fail = 0;
+    reallocf_fail = 0;
+    free_fail = 0;
+}
+
 
 pid$target::malloc:entry
 {
-    self->msize = arg0;
+    malloc_size = arg0;
+    malloc_fail = 1;
 }
 
 pid$target::malloc:return
-/self->msize/
+/malloc_fail/
 {
-    printf("malloc(%d) = %#p\n", self->msize, arg1);
-    self->msize = 0;
+    printf("malloc(%d) = %#p\n", malloc_size, arg1);
+    malloc_fail = 0;
 }
 
 pid$target::valloc:entry
 {
-    self->vsize = arg0;
+    valloc_size = arg0;
+    valloc_fail = 1;
 }
 
 pid$target::valloc:return
-/self->vsize/
+/valloc_fail/
 {
-    printf("valloc(%d) = %#p\n", self->vsize, arg1);
-    self->vsize = 0;
+    printf("valloc(%d) = %#p\n", valloc_size, arg1);
+    valloc_fail = 0;
 }
 
 pid$target::calloc:entry
 {
-    self->ccount = arg0;
-    self->csize = arg1;
+    calloc_count = arg0;
+    calloc_size = arg1;
+    calloc_fail = 1;
 }
 
 pid$target::calloc:return
-/self->csize/
+/calloc_fail/
 {
-    printf("calloc(%d, %d) = %#p\n", self->ccount, self->csize, arg1);
-    self->ccount = 0;
-    self->csize = 0;
+    printf("calloc(%d, %d) = %#p\n", calloc_count, calloc_size, arg1);
+    calloc_fail = 0;
 }
 
 pid$target::realloc:entry
 {
-    self->raddr = arg0;
-    self->rsize = arg1;
+    realloc_addr = arg0;
+    realloc_size = arg1;
+    realloc_fail = 1;
 }
 
 pid$target::realloc:return
-/self->rsize/
+/realloc_fail/
 {
-    printf("realloc(%#p, %d) = %#p\n", self->raddr, self->rsize, arg1);
-    self->rsize = 0;
-    self->raddr = 0;
+    printf("realloc(%#p, %d) = %#p\n", realloc_addr, realloc_size, arg1);
+    realloc_fail = 0;
 }
 
 pid$target::reallocf:entry
 {
-    self->rfaddr = arg0;
-    self->rfsize = arg1;
+    reallocf_addr = arg0;
+    reallocf_size = arg1;
+    reallocf_fail = 1;
 }
 
 pid$target::reallocf:return
-/self->rfsize/
+/reallocf_fail/
 {
-    printf("reallocf(%#p, %d) = %#p\n", self->rfaddr, self->rfsize, arg1);
-    self->rfaddr = 0;
-    self->rfsize = 0;
+    printf("reallocf(%#p, %d) = %#p\n", reallocf_addr, reallocf_size, arg1);
+    reallocf_fail = 0;
 }
 
 pid$target::free:entry
 {
-    printf("free(%#p) = <void>\n", arg0);
+    free_addr = arg0;
+    printf("free(%#p) = <void>\n", free_addr);
 }
 
+END
+/malloc_fail/
+{
+    printf("malloc(%d) = <error>\n", malloc_size);
+}
+
+END
+/valloc_fail/
+{
+    printf("valloc(%d) = <error>\n", valloc_size);
+}
+
+END
+/calloc_fail/
+{
+    printf("calloc(%d, %d) = <error>\n", calloc_count, calloc_size);
+}
+
+END
+/realloc_fail/
+{
+    printf("realloc(%#p, %d) = <error>\n", realloc_addr, realloc_size);
+}
+
+END
+/reallocf_fail/
+{
+    printf("realloc(%#p, %d) = <error>\n", reallocf_addr, reallocf_size);
+}

--- a/dtracetool/memtrace.d
+++ b/dtracetool/memtrace.d
@@ -20,8 +20,6 @@ to a certain degree via DTrace tuning [2] [3].
 /* Re-enable to see potential data drops */
 #pragma D option quiet
 
-#pragma D option bufsize=256m
-
 
 pid$target::malloc:entry
 {

--- a/dtracetool/memtrace.d
+++ b/dtracetool/memtrace.d
@@ -20,7 +20,6 @@ to a certain degree via DTrace tuning [2] [3].
 /* Re-enable to see potential data drops */
 #pragma D option quiet
 
-#pragma D option destructive
 #pragma D option bufsize=256m
 
 

--- a/dtracetool/memtrace.d
+++ b/dtracetool/memtrace.d
@@ -26,72 +26,112 @@ to a certain degree via DTrace tuning [2] [3].
 
 pid$target::malloc:entry
 {
-    self->msize = arg0;
+    msize = arg0;
+    malloc_fail = 1
 }
 
 pid$target::malloc:return
-/self->msize/
+/msize/
 {
-    printf("malloc(%d) = %#p\n", self->msize, arg1);
-    self->msize = 0;
+    printf("malloc(%d) = %#p\n", msize, arg1);
+    msize = 0;
+    malloc_fail = 0;
 }
 
 pid$target::valloc:entry
 {
-    self->vsize = arg0;
+    vsize = arg0;
+    valloc_fail = 1;
 }
 
 pid$target::valloc:return
-/self->vsize/
+/vsize/
 {
-    printf("valloc(%d) = %#p\n", self->vsize, arg1);
-    self->vsize = 0;
+    printf("valloc(%d) = %#p\n", vsize, arg1);
+    vsize = 0;
+    valloc_fail = 0;
 }
 
 pid$target::calloc:entry
 {
-    self->ccount = arg0;
-    self->csize = arg1;
+    ccount = arg0;
+    csize = arg1;
+    calloc_fail = 1;
 }
 
 pid$target::calloc:return
-/self->csize/
+/csize/
 {
-    printf("calloc(%d, %d) = %#p\n", self->ccount, self->csize, arg1);
-    self->ccount = 0;
-    self->csize = 0;
+    printf("calloc(%d, %d) = %#p\n", ccount, csize, arg1);
+    ccount = 0;
+    csize = 0;
+    calloc_fail = 0;
 }
 
 pid$target::realloc:entry
 {
-    self->raddr = arg0;
-    self->rsize = arg1;
+    raddr = arg0;
+    rsize = arg1;
+    realloc_fail = 1;
 }
 
 pid$target::realloc:return
-/self->rsize/
+/rsize/
 {
-    printf("realloc(%#p, %d) = %#p\n", self->raddr, self->rsize, arg1);
-    self->rsize = 0;
-    self->raddr = 0;
+    printf("realloc(%#p, %d) = %#p\n", raddr, rsize, arg1);
+    rsize = 0;
+    raddr = 0;
+    realloc_fail = 0;
 }
 
 pid$target::reallocf:entry
 {
-    self->rfaddr = arg0;
-    self->rfsize = arg1;
+    rfaddr = arg0;
+    rfsize = arg1;
+    reallocf_fail = 1;
 }
 
 pid$target::reallocf:return
-/self->rfsize/
+/rfsize/
 {
-    printf("reallocf(%#p, %d) = %#p\n", self->rfaddr, self->rfsize, arg1);
-    self->rfaddr = 0;
-    self->rfsize = 0;
+    printf("reallocf(%#p, %d) = %#p\n", rfaddr, rfsize, arg1);
+    rfaddr = 0;
+    rfsize = 0;
+    reallocf_fail = 0;
 }
 
 pid$target::free:entry
 {
-    printf("free(%#p) = 0\n", arg0);
+    printf("free(%#p) = <void>\n", arg0);
+}
+
+dtrace:::END
+/malloc_fail == 1/
+{
+    printf("malloc(%d) = <error>\n", msize);
+}
+
+dtrace:::END
+/valloc_fail == 1/
+{
+    printf("valloc(%d) = <error>\n", vsize);
+}
+
+dtrace:::END
+/calloc_fail == 1/
+{
+    printf("calloc(%d, %d) = <error>\n", ccount, csize);
+}
+
+dtrace:::END
+/realloc_fail == 1/
+{
+    printf("realloc(%#p, %d) = <error>\n", raddr, rsize);
+}
+
+dtrace:::END
+/reallocf_fail == 1/
+{
+    printf("reallocf(%#p, %d) = <error>\n", rfaddr, rfsize);
 }
 

--- a/dtracetool/tests/Makefile
+++ b/dtracetool/tests/Makefile
@@ -1,0 +1,17 @@
+CC = clang
+
+all: test1 test2 test3
+
+test1: test1.c
+	$(CC) -o test1 test1.c
+
+test2: test2.c
+	$(CC) -o test2 test2.c
+
+test3: test3.c
+	$(CC) -o test3 test3.c
+
+clean:
+	rm test1
+	rm test2
+	rm test3

--- a/dtracetool/tests/test1.c
+++ b/dtracetool/tests/test1.c
@@ -1,3 +1,5 @@
+/* Testing for each alloc function from libc */
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/dtracetool/tests/test1.c
+++ b/dtracetool/tests/test1.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#define DEBUG 0
+
+int 
+main(void)
+{
+    int *cptr, *mptr, *vptr;
+
+    cptr = calloc(8, 32);
+    if(DEBUG)
+        printf("cptr = %p\n", cptr);
+
+    mptr = malloc(64);
+    if(DEBUG)
+        printf("mptr = %p\n", mptr);
+
+    mptr = realloc(mptr, 128);
+    if(DEBUG)
+        printf("mptr = %p\n", mptr);
+
+    vptr = valloc(64);
+    if(DEBUG)
+        printf("vptr = %p\n", vptr);
+
+    vptr = reallocf(vptr, 128);
+    if(DEBUG)
+        printf("vptr = %p\n", vptr);
+
+    free(cptr);
+    free(mptr);
+    free(vptr);
+
+    return 0;
+}
+

--- a/dtracetool/tests/test2.c
+++ b/dtracetool/tests/test2.c
@@ -1,3 +1,5 @@
+/* Testing for fail/success of alloc functions */
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/dtracetool/tests/test2.c
+++ b/dtracetool/tests/test2.c
@@ -1,0 +1,67 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#define DEBUG 0
+
+int 
+main(void)
+{
+    int *cptr, *mptr, *vptr, *rptr, *rfptr;
+
+    /* Failing calloc */
+    cptr = calloc(1337, 0xFFFFFFFFFFFF);
+    if(DEBUG)
+        printf("cptr = %p\n", cptr);
+
+    /* Succeeding calloc */
+    cptr = calloc(8, 32);
+    if(DEBUG)
+        printf("cptr = %p\n", cptr);
+
+    /* Failing malloc */
+    mptr = malloc(0xFFFFFFFFFFFFFF);
+    if(DEBUG)
+        printf("mptr = %p\n", mptr);
+
+    /* Succeeding malloc */
+    mptr = malloc(64);
+    if(DEBUG)
+        printf("mptr = %p\n", mptr);
+
+    /* Failing realloc, we want to test if mptr is still valid */
+    rptr = realloc(mptr, 0xFFFFFFFFFFFF);
+    if(DEBUG)
+        printf("mptr = %p\n", mptr);
+
+    /* Succeeding realloc */
+    mptr = realloc(mptr, 128);
+    if(DEBUG)
+        printf("mptr = %p\n", mptr);
+
+    /* Failing valloc */
+    vptr = valloc(0xFFFFFFFFFFFF);
+    if(DEBUG)
+        printf("vptr = %p\n", vptr);
+
+    /* Succeeding valloc */
+    vptr = valloc(64);
+    if(DEBUG)
+        printf("vptr = %p\n", vptr);
+
+    /* Succeeding reallocf */
+    vptr = reallocf(vptr, 128);
+    if(DEBUG)
+        printf("vptr = %p\n", vptr);
+
+    /* Failing reallocf, we want to test if vptr is still valid */
+    rfptr = reallocf(vptr, 0xFFFFFFFFFFFF);
+    if(DEBUG)
+        printf("vptr = %p\n", vptr);
+
+    free(cptr);
+    free(mptr);
+//    free(vptr);
+
+    return 0;
+}
+

--- a/dtracetool/tests/test3.c
+++ b/dtracetool/tests/test3.c
@@ -1,0 +1,34 @@
+/* Testing for a crash inside of the malloc() */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+  (void) argc, (void) argv;
+
+  void *a, *b, *c;
+
+  a = malloc(48);
+  b = malloc(48);
+  c = malloc(48);
+
+  free(a);
+
+  // Let's say we have an underflow on c. This
+  // is far from the only way to trigger a crash.
+  memset(c-128, 0xff, 0x200);
+
+  printf("A crash in malloc will be triggered *after* this print.\n");
+  malloc(48);
+
+  printf("This shouldn't be reached but it is on OS X (unlike Ubuntu)\n");
+  malloc(48);
+
+  printf("However, this isn't reached\n");
+  malloc(1337);
+
+  return 0;
+}
+

--- a/villoc.py
+++ b/villoc.py
@@ -159,6 +159,9 @@ def malloc(state, ret, size):
         state.append(Block(ret, size))
 
 
+def valloc(state, ret, size):
+    malloc(state, ret, size)
+
 def calloc(state, ret, nmemb, size):
     malloc(state, ret, nmemb * size)
 
@@ -200,6 +203,7 @@ def realloc(state, ret, ptr, size):
 operations = {
     'free': free,
     'malloc': malloc,
+    'valloc': valloc,
     'calloc': calloc,
     'realloc': realloc,
 }

--- a/villoc.py
+++ b/villoc.py
@@ -223,6 +223,8 @@ operations = {
 def sanitize(x):
     if x is None:
         return None
+    if x == "<error>":
+        return None
     if x == "<void>":
         return 0
     return int(x, 0)

--- a/villoc.py
+++ b/villoc.py
@@ -187,6 +187,8 @@ def realloc(state, ret, ptr, size):
 
     if not ptr:
         return malloc(state, ret, size)
+    elif not ret:
+        return malloc(state, ret, size)
     elif not size:
         return free(state, ret, ptr)
 

--- a/villoc.py
+++ b/villoc.py
@@ -162,6 +162,7 @@ def malloc(state, ret, size):
 def valloc(state, ret, size):
     malloc(state, ret, size)
 
+
 def calloc(state, ret, nmemb, size):
     malloc(state, ret, nmemb * size)
 
@@ -198,6 +199,13 @@ def realloc(state, ret, ptr, size):
         state[s].error = True
     else:
         state[s] = Block(ret, size, color=match.color)
+ 
+
+# This is just an empty stub for reallocf(). This is because internally
+# reallocf() calls realloc() so we catch it there.
+# However, for the sake of completness it's good to have it in the output.
+def reallocf(state, ret, ptr, size):
+    return
 
 
 operations = {
@@ -206,6 +214,7 @@ operations = {
     'valloc': valloc,
     'calloc': calloc,
     'realloc': realloc,
+    'reallocf': reallocf,
 }
 
 


### PR DESCRIPTION
Following commits enable usage of DTrace on OS X platform as `ltrace` replacement.
