### PR TITLE
Bugfix for lines starting with the PID.

### DIFF
--- a/villoc.py
+++ b/villoc.py
@@ -219,25 +219,24 @@ def parse_ltrace(ltrace):
     match_err = r"^([a-z_]+)\((.*) <no return \.\.\.>"
 
     for line in ltrace:
+
         # if the trace file contains PID (for ltrace -f)
-        try:
-            if line.split(' ')[0].isdigit():
-                line = ' '.join(line.split(' ')[1:])
-        except IndexError:
-            pass
+        head, _, tail = line.partition(" ")
+        if head.isdigit():
+            line = tail
 
         if not any(line.startswith(f) for f in operations):
             continue
 
         try:
             func, args, ret = re.findall(match_call, line)[0]
-        except:
+        except Exception:
 
             try:
-                # maybe this stoped the program
+                # maybe this stopped the program
                 func, args = re.findall(match_err, line)[0]
                 ret = None
-            except:
+            except Exception:
                 print("ignoring line: %s" % line, file=sys.stderr)
                 continue
 

--- a/villoc.py
+++ b/villoc.py
@@ -219,6 +219,12 @@ def parse_ltrace(ltrace):
     match_err = r"^([a-z_]+)\((.*) <no return \.\.\.>"
 
     for line in ltrace:
+        # if the trace file contains PID (for ltrace -f)
+        try:
+            if line.split(' ')[0].isdigit():
+                line = ' '.join(line.split(' ')[1:])
+        except IndexError:
+            pass
 
         if not any(line.startswith(f) for f in operations):
             continue


### PR DESCRIPTION
This is useful when ltrace is used with "-f" option.
