### PR TITLE
add dynamorio tracer hooking libc internal allocation

### DIFF
--- a/tracers/dynamorio/CMakeLists.txt
+++ b/tracers/dynamorio/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 2.8)
+
+add_library(villoc_tracer SHARED villoc_tracer.c)
+find_package(DynamoRIO)
+if (NOT DynamoRIO_FOUND)
+  message(FATAL_ERROR "DynamoRIO package required to build")
+endif(NOT DynamoRIO_FOUND)
+use_DynamoRIO_extension(villoc_tracer drwrap)
+use_DynamoRIO_extension(villoc_tracer drmgr)
+
+
+set(DynamoRIO_USE_LIBC OFF)
+configure_DynamoRIO_client(villoc_tracer)

--- a/tracers/dynamorio/README.md
+++ b/tracers/dynamorio/README.md
@@ -2,11 +2,16 @@
 [DynamoRIO](https://github.com/DynamoRIO/dynamorio)
 
 ## Build
-Set the environment variable DYNAMORIO_HOME to the absolute path of your DynamoRIO installation\
-Execute `./build.sh`\
+Set the environment variable DYNAMORIO_HOME to the absolute path of your DynamoRIO installation
+
+Execute `./build.sh`
+
+
 To compile the tracer for a 32bits target on a 64bits os execute `./build.sh 32`
 
 ## usage
-`$DYNAMORIO_HOME/bin64/drrun -c villoc_tracer -- ./target |& ./villoc.py - out.html;`\
-For a 32 bit target on a 64 bit OS:\
+`$DYNAMORIO_HOME/bin64/drrun -c villoc_tracer -- ./target |& ./villoc.py - out.html;`
+
+For a 32 bit target on a 64 bit OS:
+
 `$DYNAMORIO_HOME/bin32/drrun -c villoc_tracer -- ./target |& ./villoc.py - out.html;`

--- a/tracers/dynamorio/README.md
+++ b/tracers/dynamorio/README.md
@@ -1,0 +1,12 @@
+## Requirement
+[DynamoRIO](https://github.com/DynamoRIO/dynamorio)
+
+## Build
+Set the environment variable DYNAMORIO_HOME to the absolute path of your DynamoRIO installation\
+Execute `./build.sh`\
+To compile the tracer for a 32bits target on a 64bits os execute `./build.sh 32`
+
+## usage
+`$DYNAMORIO_HOME/bin64/drrun -c villoc_tracer -- ./target |& ./villoc.py - out.html;`\
+For a 32 bit target on a 64 bit OS:\
+`$DYNAMORIO_HOME/bin32/drrun -c villoc_tracer -- ./target |& ./villoc.py - out.html;`

--- a/tracers/dynamorio/build.sh
+++ b/tracers/dynamorio/build.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+rm -rf build
+
+mkdir build
+cd build
+
+if [ $# -eq 1 ] && [ $1 -eq 32 ]
+then
+    CFLAGS="-W -Wall -Wextra -std=gnu99 -nostdlib -fno-builtin -O3 -m32 " CXXFLAGS=-m32 cmake -DDynamoRIO_DIR=$DYNAMORIO_HOME/cmake ../ && make && cp libvilloc_tracer.so ../villoc_tracer
+else
+    CFLAGS="-W -Wall -Wextra -std=gnu99 -nostdlib -fno-builtin -O3 " cmake -DDynamoRIO_DIR=$DYNAMORIO_HOME/cmake ../ && make && cp libvilloc_tracer.so ../villoc_tracer
+fi

--- a/tracers/dynamorio/build.sh
+++ b/tracers/dynamorio/build.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+SCRIPT_PATH=${0%/*}
+if [ "$0" != "$SCRIPT_PATH" ] && [ "$SCRIPT_PATH" != "" ]; then
+    cd $SCRIPT_PATH
+fi
+
 rm -rf build
 
 mkdir build

--- a/tracers/dynamorio/villoc_tracer.c
+++ b/tracers/dynamorio/villoc_tracer.c
@@ -3,159 +3,144 @@
 #include "drwrap.h"
 #include "drmgr.h"
 
-// reallocarray is the longest possible string to log
-// so the max size the realloc can have will be the of the per thread logging
-#define BUF_SIZE (27 + 19 * 2 + 20 * 2)
+#define BUF_SIZE (1024)
 
 int tls_idx;
 
-void reset_buf()
+void reset_buf(char *buf)
 {
-  void *drc = dr_get_current_drcontext();
-
-  char *buf = drmgr_get_tls_field(drc, tls_idx);
   for (size_t i = 0; i < BUF_SIZE; i++)
     buf[i] = 0;
 }
 
-void pre_malloc(void *wrapctx, OUT void **user_data)
+void pre_malloc(void *wrapctx, OUT void **buf_ptr)
 {
   void *drc = dr_get_current_drcontext();
   char *buf = drmgr_get_tls_field(drc, tls_idx);
 
-  *user_data = (void *)1;
-
   // another print is in buf, so ignoring this call
   if (buf[0] != 0)
     {
-      *user_data = NULL;
+      *buf_ptr = NULL;
       return;
     }
+  else
+    *buf_ptr = buf;
 
   dr_snprintf(buf, BUF_SIZE, "malloc(%d", drwrap_get_arg(wrapctx, 0));
 }
 
-void post_malloc(void *wrapctx, void *user_data)
+void post_malloc(void *wrapctx, void *buf_ptr)
 {
-  void *drc = dr_get_current_drcontext();
-
-  if (user_data == NULL)
+  if (buf_ptr == NULL)
     return;
 
-  dr_printf("%s) = %p\n", drmgr_get_tls_field(drc, tls_idx), drwrap_get_retval(wrapctx));
-  reset_buf();
+  dr_printf("%s) = %p\n", buf_ptr, drwrap_get_retval(wrapctx));
+  reset_buf(buf_ptr);
 }
 
-void pre_calloc(void *wrapctx, OUT void **user_data)
+void pre_calloc(void *wrapctx, OUT void **buf_ptr)
 {
   void *drc = dr_get_current_drcontext();
   char *buf = drmgr_get_tls_field(drc, tls_idx);
 
-  *user_data = (void *)1;
-
   // another print is in buf, so ignoring this call
   if (buf[0] != 0)
     {
-      *user_data = NULL;
+      *buf_ptr = NULL;
       return;
     }
+  else
+    *buf_ptr = buf;
 
-  dr_snprintf(drmgr_get_tls_field(drc, tls_idx), BUF_SIZE, "calloc(%zu, %zu", drwrap_get_arg(wrapctx, 0), drwrap_get_arg(wrapctx, 1));
+  dr_snprintf(buf, BUF_SIZE, "calloc(%zu, %zu", drwrap_get_arg(wrapctx, 0), drwrap_get_arg(wrapctx, 1));
 }
 
-void post_calloc(void *wrapctx, void *user_data)
+void post_calloc(void *wrapctx, void *buf_ptr)
 {
-  void *drc = dr_get_current_drcontext();
-
-  if (user_data == NULL)
+  if (buf_ptr == NULL)
     return;
 
-  dr_printf("%s) = %p\n", drmgr_get_tls_field(drc, tls_idx), drwrap_get_retval(wrapctx));
-  reset_buf();
+  dr_printf("%s) = %p\n", buf_ptr, drwrap_get_retval(wrapctx));
+  reset_buf(buf_ptr);
 }
 
-void pre_reallocarray(void *wrapctx, OUT void **user_data)
+void pre_reallocarray(void *wrapctx, OUT void **buf_ptr)
 {
   void *drc = dr_get_current_drcontext();
   char *buf = drmgr_get_tls_field(drc, tls_idx);
 
-  *user_data = (void *)1;
-
   // another print is in buf, so ignoring this call
   if (buf[0] != 0)
     {
-      *user_data = NULL;
+      *buf_ptr = NULL;
       return;
     }
+  else
+    *buf_ptr = buf;
 
-  dr_snprintf(drmgr_get_tls_field(drc, tls_idx), BUF_SIZE, "reallocarray(%p, %zu, %zu", drwrap_get_arg(wrapctx, 0), drwrap_get_arg(wrapctx, 1), drwrap_get_arg(wrapctx, 2));
+  dr_snprintf(buf, BUF_SIZE, "reallocarray(%p, %zu, %zu", drwrap_get_arg(wrapctx, 0), drwrap_get_arg(wrapctx, 1), drwrap_get_arg(wrapctx, 2));
 }
 
-void post_reallocarray(void *wrapctx, void *user_data)
+void post_reallocarray(void *wrapctx, void *buf_ptr)
 {
-  void *drc = dr_get_current_drcontext();
-
-  if (user_data == NULL)
+  if (buf_ptr == NULL)
     return;
 
-  dr_printf("%s) = %p\n", drmgr_get_tls_field(drc, tls_idx), drwrap_get_retval(wrapctx));
-  reset_buf();
+  dr_printf("%s) = %p\n", buf_ptr, drwrap_get_retval(wrapctx));
+  reset_buf(buf_ptr);
 }
 
-void pre_realloc(void *wrapctx, OUT void **user_data)
+void pre_realloc(void *wrapctx, OUT void **buf_ptr)
 {
   void *drc = dr_get_current_drcontext();
   char *buf = drmgr_get_tls_field(drc, tls_idx);
 
-  *user_data = (void *)1;
-
   // another print is in buf, so ignoring this call
   if (buf[0] != 0)
     {
-      *user_data = NULL;
+      *buf_ptr = NULL;
       return;
     }
+  else
+    *buf_ptr = buf;
 
-  dr_snprintf(drmgr_get_tls_field(drc, tls_idx), BUF_SIZE, "realloc(%p, %zu", drwrap_get_arg(wrapctx, 0), drwrap_get_arg(wrapctx, 1));
+  dr_snprintf(buf, BUF_SIZE, "realloc(%p, %zu", drwrap_get_arg(wrapctx, 0), drwrap_get_arg(wrapctx, 1));
 }
 
-void post_realloc(void *wrapctx, void *user_data)
+void post_realloc(void *wrapctx, void *buf_ptr)
 {
-  void *drc = dr_get_current_drcontext();
-
-  if (user_data == NULL)
+  if (buf_ptr == NULL)
     return;
 
-  dr_printf("%s) = %p\n", drmgr_get_tls_field(drc, tls_idx), drwrap_get_retval(wrapctx));
-  reset_buf();
+  dr_printf("%s) = %p\n", buf_ptr, drwrap_get_retval(wrapctx));
+  reset_buf(buf_ptr);
 }
 
-void pre_free(void *wrapctx, OUT void **user_data)
+void pre_free(void *wrapctx, OUT void **buf_ptr)
 {
   void *drc = dr_get_current_drcontext();
   char *buf = drmgr_get_tls_field(drc, tls_idx);
 
-  *user_data = (void *)1;
-
   // another print is in buf, so ignoring this call
   if (buf[0] != 0)
     {
-      *user_data = NULL;
+      *buf_ptr = NULL;
       return;
     }
+  else
+    *buf_ptr = buf;
 
-  dr_snprintf(drmgr_get_tls_field(drc, tls_idx), BUF_SIZE, "free(%p", drwrap_get_arg(wrapctx, 0));
+  dr_snprintf(buf, BUF_SIZE, "free(%p", drwrap_get_arg(wrapctx, 0));
 }
 
-void post_free(void *wrapctx, void *user_data)
+void post_free(void *wrapctx, void *buf_ptr)
 {
-  void *drc = dr_get_current_drcontext();
-
-  if (user_data == NULL)
+  if (buf_ptr == NULL)
     return;
 
-  dr_printf("%s) = <void>\n", drmgr_get_tls_field(drc, tls_idx), drwrap_get_retval(wrapctx));
-  reset_buf();
+  dr_printf("%s) = <void>\n", buf_ptr, drwrap_get_retval(wrapctx));
+  reset_buf(buf_ptr);
 }
 
 void load_event(__attribute__((unused))void *drcontext,
@@ -189,7 +174,7 @@ void thread_init_event(void *drc)
   char *buf = dr_global_alloc(BUF_SIZE);
 
   drmgr_set_tls_field(drc, tls_idx, buf);
-  reset_buf();
+  reset_buf(buf);
 }
 
 void thread_exit_event(void *drc)

--- a/tracers/dynamorio/villoc_tracer.c
+++ b/tracers/dynamorio/villoc_tracer.c
@@ -1,0 +1,237 @@
+#include "dr_api.h"
+#include "dr_tools.h"
+#include "drwrap.h"
+#include "drmgr.h"
+
+// reallocarray is the longest possible string to log
+// so the max size the realloc can have will be the of the per thread logging
+#define BUF_SIZE (27 + 19 * 2 + 20 * 2)
+
+int tls_idx;
+
+void reset_buf()
+{
+  void *drc = dr_get_current_drcontext();
+
+  char *buf = drmgr_get_tls_field(drc, tls_idx);
+  for (size_t i = 0; i < BUF_SIZE; i++)
+    buf[i] = 0;
+}
+
+void pre_malloc(void *wrapctx, OUT void **user_data)
+{
+  void *drc = dr_get_current_drcontext();
+  char *buf = drmgr_get_tls_field(drc, tls_idx);
+
+  *user_data = (void *)1;
+
+  // another print is in buf, so ignoring this call
+  if (buf[0] != 0)
+    {
+      *user_data = NULL;
+      return;
+    }
+
+  dr_snprintf(buf, BUF_SIZE, "malloc(%d", drwrap_get_arg(wrapctx, 0));
+}
+
+void post_malloc(void *wrapctx, void *user_data)
+{
+  void *drc = dr_get_current_drcontext();
+
+  if (user_data == NULL)
+    return;
+
+  dr_printf("%s) = %p\n", drmgr_get_tls_field(drc, tls_idx), drwrap_get_retval(wrapctx));
+  reset_buf();
+}
+
+void pre_calloc(void *wrapctx, OUT void **user_data)
+{
+  void *drc = dr_get_current_drcontext();
+  char *buf = drmgr_get_tls_field(drc, tls_idx);
+
+  *user_data = (void *)1;
+
+  // another print is in buf, so ignoring this call
+  if (buf[0] != 0)
+    {
+      *user_data = NULL;
+      return;
+    }
+
+  dr_snprintf(drmgr_get_tls_field(drc, tls_idx), BUF_SIZE, "calloc(%zu, %zu", drwrap_get_arg(wrapctx, 0), drwrap_get_arg(wrapctx, 1));
+}
+
+void post_calloc(void *wrapctx, void *user_data)
+{
+  void *drc = dr_get_current_drcontext();
+
+  if (user_data == NULL)
+    return;
+
+  dr_printf("%s) = %p\n", drmgr_get_tls_field(drc, tls_idx), drwrap_get_retval(wrapctx));
+  reset_buf();
+}
+
+void pre_reallocarray(void *wrapctx, OUT void **user_data)
+{
+  void *drc = dr_get_current_drcontext();
+  char *buf = drmgr_get_tls_field(drc, tls_idx);
+
+  *user_data = (void *)1;
+
+  // another print is in buf, so ignoring this call
+  if (buf[0] != 0)
+    {
+      *user_data = NULL;
+      return;
+    }
+
+  dr_snprintf(drmgr_get_tls_field(drc, tls_idx), BUF_SIZE, "reallocarray(%p, %zu, %zu", drwrap_get_arg(wrapctx, 0), drwrap_get_arg(wrapctx, 1), drwrap_get_arg(wrapctx, 2));
+}
+
+void post_reallocarray(void *wrapctx, void *user_data)
+{
+  void *drc = dr_get_current_drcontext();
+
+  if (user_data == NULL)
+    return;
+
+  dr_printf("%s) = %p\n", drmgr_get_tls_field(drc, tls_idx), drwrap_get_retval(wrapctx));
+  reset_buf();
+}
+
+void pre_realloc(void *wrapctx, OUT void **user_data)
+{
+  void *drc = dr_get_current_drcontext();
+  char *buf = drmgr_get_tls_field(drc, tls_idx);
+
+  *user_data = (void *)1;
+
+  // another print is in buf, so ignoring this call
+  if (buf[0] != 0)
+    {
+      *user_data = NULL;
+      return;
+    }
+
+  dr_snprintf(drmgr_get_tls_field(drc, tls_idx), BUF_SIZE, "realloc(%p, %zu", drwrap_get_arg(wrapctx, 0), drwrap_get_arg(wrapctx, 1));
+}
+
+void post_realloc(void *wrapctx, void *user_data)
+{
+  void *drc = dr_get_current_drcontext();
+
+  if (user_data == NULL)
+    return;
+
+  dr_printf("%s) = %p\n", drmgr_get_tls_field(drc, tls_idx), drwrap_get_retval(wrapctx));
+  reset_buf();
+}
+
+void pre_free(void *wrapctx, OUT void **user_data)
+{
+  void *drc = dr_get_current_drcontext();
+  char *buf = drmgr_get_tls_field(drc, tls_idx);
+
+  *user_data = (void *)1;
+
+  // another print is in buf, so ignoring this call
+  if (buf[0] != 0)
+    {
+      *user_data = NULL;
+      return;
+    }
+
+  dr_snprintf(drmgr_get_tls_field(drc, tls_idx), BUF_SIZE, "free(%p", drwrap_get_arg(wrapctx, 0));
+}
+
+void post_free(void *wrapctx, void *user_data)
+{
+  void *drc = dr_get_current_drcontext();
+
+  if (user_data == NULL)
+    return;
+
+  dr_printf("%s) = <void>\n", drmgr_get_tls_field(drc, tls_idx), drwrap_get_retval(wrapctx));
+  reset_buf();
+}
+
+void load_event(__attribute__((unused))void *drcontext,
+		       const module_data_t *mod,
+		       __attribute__((unused))bool loaded)
+{
+  app_pc malloc = (app_pc)dr_get_proc_address(mod->handle, "__libc_malloc");
+  app_pc calloc = (app_pc)dr_get_proc_address(mod->handle, "__libc_calloc");
+  app_pc realloc = (app_pc)dr_get_proc_address(mod->handle, "__libc_realloc");
+  app_pc free = (app_pc)dr_get_proc_address(mod->handle, "__libc_free");
+  app_pc reallocarray = (app_pc)dr_get_proc_address(mod->handle, "__libc_reallocarray");
+
+  if (malloc)
+    DR_ASSERT(drwrap_wrap(malloc, pre_malloc, post_malloc));
+
+  if (calloc)
+    DR_ASSERT(drwrap_wrap(calloc, pre_calloc, post_calloc));
+
+  if (realloc)
+    DR_ASSERT(drwrap_wrap(realloc, pre_realloc, post_realloc));
+
+  if (free)
+    DR_ASSERT(drwrap_wrap(free, pre_free, post_free));
+
+  if(reallocarray)
+    DR_ASSERT(drwrap_wrap(reallocarray, pre_reallocarray, post_reallocarray));
+}
+
+void thread_init_event(void *drc)
+{
+  char *buf = dr_global_alloc(BUF_SIZE);
+
+  drmgr_set_tls_field(drc, tls_idx, buf);
+  reset_buf();
+}
+
+void thread_exit_event(void *drc)
+{
+  char *buf = drmgr_get_tls_field(drc, tls_idx);
+
+  if (buf[0] != 0)
+    dr_printf("%s <no return ...>\n", buf);
+  dr_global_free(buf, BUF_SIZE);
+}
+
+void exit_event(void)
+{
+  drwrap_exit();
+  drmgr_exit();
+}
+
+DR_EXPORT void dr_client_main(client_id_t __attribute__((unused))id,
+			      __attribute__((unused))int argc,
+			      __attribute__((unused))const char *argv[])
+{
+  drmgr_priority_t      p = {
+    sizeof(p),
+    "Print allocation trace for Villoc",
+    NULL,
+    NULL,
+    0};
+
+  dr_set_client_name("Villoc_dbi", "ampotos@gmail.com");
+
+  drwrap_init();
+  drmgr_init();
+
+  dr_register_exit_event(&exit_event);
+  if (!drmgr_register_module_load_event(&load_event))
+    DR_ASSERT_MSG(false, "Can't register module load event handler\n");
+  if (!drmgr_register_thread_init_event(&thread_init_event))
+    DR_ASSERT_MSG(false, "Can't register thread init event handler\n");
+  if (!drmgr_register_thread_exit_event(&thread_exit_event))
+    DR_ASSERT_MSG(false, "Can't register thread init exit handler\n");
+
+  // register a slot per thread for logging
+  tls_idx = drmgr_register_tls_field();
+  DR_ASSERT_MSG(tls_idx != -1, "Can't register tls field\n");
+}


### PR DESCRIPTION
A DynamoRIO tool which hook the internal allocator of the libc and print the allocation detail in the right format for villoc.
Tested successfully against /bin/ls;