### PR TITLE
Replaced "is 0" by "== 0"

### DIFF
--- a/villoc.py
+++ b/villoc.py
@@ -185,7 +185,7 @@ def calloc(state, ret, nmemb, size):
 
 def free(state, ret, ptr):
 
-    if ptr is 0:
+    if ptr == 0:
         return
 
     s, match = match_ptr(state, ptr)


### PR DESCRIPTION
This causes a SyntaxWarning since python 3.8